### PR TITLE
tweaks to infrastructure files to get them to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # Django
 media/
 static/
+
+# Pycharm
+.idea/

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -9,7 +9,7 @@ RUN echo @edge http://nl.alpinelinux.org/alpine/latest-stable/community >> /etc/
     harfbuzz \
     "freetype>2.8" \
     ttf-freefont \
-    nss@edge \
+    nss \
     && rm -rf /var/cache/* \
     && mkdir /var/cache/apk
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
   taxi-database:
     container_name: taxi-database
     environment:
+      - POSTGRES_USER=taxi
       - POSTGRES_PASSWORD=taxi
+      - POSTGRES_DB=taxi
     image: postgres:14.1
     ports:
       - 5433:5432

--- a/server/.env
+++ b/server/.env
@@ -1,0 +1,5 @@
+PGDATABASE=taxi
+PGUSER=taxi
+PGPASSWORD=taxi
+PGHOST=taxi-database
+REDIS_URL=redis://taxi-redis:6379/0


### PR DESCRIPTION
here are a few suggestions to address some issues I ran into with the docker infrastructure files

- in client/Dockerfile the nss@edge tag does not currently seem to be available any longer, changed to simply nss
- in docker-compose.yml need to specify the POSTGRES_USER and POSTGRES_DB to match the instructions from the tutorial
- add missing .env file